### PR TITLE
feat: circuit is getting converted to png

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ dist
 
 node_modules/
 dist/
+
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "circuit-to-png",
   "module": "index.ts",
-  "type": "module",
   "scripts": {
     "prepublish": "npm run build",
     "build": "tsup ./src/index.ts --dts --sourcemap",
@@ -14,9 +13,12 @@
     "tsup": "^8.2.3"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@tscircuit/soup": "^0.0.41"
+    "@resvg/resvg-js": "^2.6.2",
+    "@resvg/resvg-wasm": "^2.6.2",
+    "@tscircuit/soup": "^0.0.41",
+    "@tscircuit/soup-to-svg": "^0.0.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,1 @@
-import type { AnySoupElement } from "@tscircuit/soup";
-
-export function soupToPng(soup: AnySoupElement[]) {
-    // SOUP to PNG LOGIC
-  return "";
-}
+export * from "./lib/svg-to-png";

--- a/src/lib/svg-to-png.ts
+++ b/src/lib/svg-to-png.ts
@@ -1,0 +1,26 @@
+import { promises } from 'node:fs'
+import { join } from 'node:path'
+import { Resvg } from '@resvg/resvg-js'
+import { pcbSoupToSvg, soupToSvg } from '@tscircuit/soup-to-svg'
+import type { AnySoupElement } from '@tscircuit/soup'
+
+async function soupToPng(soup: AnySoupElement[]) {
+  const svg = pcbSoupToSvg(soup)
+  const opts = {
+    background: 'rgba(238, 235, 230, .9)',
+    fitTo: {
+      mode: 'width' as const,
+      value: 1200,
+    },
+  }
+  const resvg = new Resvg(svg, opts)
+  const pngData = resvg.render()
+  const pngBuffer = pngData.asPng()
+
+  console.info('Original SVG Size:', `${resvg.width} x ${resvg.height}`)
+  console.info('Output PNG Size  :', `${pngData.width} x ${pngData.height}`)
+
+  await promises.writeFile(join(__dirname, './output.png'), pngBuffer)
+}
+
+export { soupToPng }


### PR DESCRIPTION
Tested the code with the soup passed to `soup-to-svg` functions and .png file getting output, as required of that svg file  ✅

The `soup-to-svg` package is not released yet, as you are still in the process. But I have added `soup-to-svg` package version as `^0.0.1` which should be good after that.